### PR TITLE
Workaround for fractals that grow to infinity, actual file dialogs on Windows.

### DIFF
--- a/Fractal_Iterator.cpp
+++ b/Fractal_Iterator.cpp
@@ -63,7 +63,12 @@ void Fractal_Iterator::IterateToInfinity() {
 
     IterateTo(ITERATOR_LEVELS);
     Fractal_Element nextFe = m_levels[ITERATOR_LEVELS];
-    while (nextFe.GetMaxLength() > config::infinity_stop_size) {
+    if (nextFe.GetMaxLength() < nextFe.BaseLength()) {
+        while (nextFe.GetMaxLength() > config::infinity_stop_size) {
+            nextFe = nextFe.ReplaceAll(m_base);
+        }
+    }
+    else {
         nextFe = nextFe.ReplaceAll(m_base);
     }
     m_levels.push_back(nextFe);

--- a/Runner.cpp
+++ b/Runner.cpp
@@ -3,6 +3,10 @@
 #include "gui/button.h"
 #include "gui/text.h"
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 Runner::Runner(sf::RenderWindow& window, sf::RenderWindow& iter_window, sf::Font& font) :
     m_window(window),
     m_font(font),
@@ -103,7 +107,29 @@ void Runner::HandleEvents() {
                             m_finishedTemplate = false;
                             m_drawingLine = false;
                         } else if(iii == 11) {
-                            if(m_base.LoadFromFile(m_elements[12]->GetText())) {
+                            std::string name = m_elements[12]->GetText();
+#ifdef _WIN32
+                            if (name.size() == 0) {
+                                TCHAR fn[256];
+                                fn[0] = '\0';
+                                OPENFILENAME ofn = { 0 };
+                                ofn.lStructSize = sizeof(ofn);
+                                ofn.hwndOwner = m_window.getSystemHandle();
+                                ofn.lpstrFile = fn;
+                                ofn.nMaxFile = sizeof(fn) / sizeof(fn[0]);
+                                ofn.lpstrFilter = "FractaSketch file (.fsk)\0*.fsk\0All Files\0*.*\0";
+                                ofn.nFilterIndex = 0;
+                                ofn.lpstrFileTitle = NULL;
+                                ofn.nMaxFileTitle = 0;
+                                ofn.lpstrInitialDir = NULL;
+                                ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
+
+                                GetOpenFileName(&ofn);
+
+                                name = fn;
+                            }
+#endif
+                            if(m_base.LoadFromFile(name)) {
                                 m_success.SetText("Load Successful!");
                                 m_startedTemplate = true;
                                 m_finishedTemplate = true;
@@ -116,7 +142,29 @@ void Runner::HandleEvents() {
                                 m_drawingLine = false;
                             }
                         } else if(iii == 13) {
-                            if(m_base.SaveToFile(m_elements[14]->GetText())) {
+                            std::string name = m_elements[14]->GetText();
+#ifdef _WIN32
+                            if (name.size() == 0) {
+                                TCHAR fn[256];
+                                fn[0] = '\0';
+                                OPENFILENAME ofn = { 0 };
+                                ofn.lStructSize = sizeof(ofn);
+                                ofn.hwndOwner = m_window.getSystemHandle();
+                                ofn.lpstrFile = fn;
+                                ofn.nMaxFile = sizeof(fn) / sizeof(fn[0]);
+                                ofn.lpstrFilter = "FractaSketch file (.fsk)\0*.fsk\0All Files\0*.*\0";
+                                ofn.nFilterIndex = 0;
+                                ofn.lpstrFileTitle = NULL;
+                                ofn.nMaxFileTitle = 0;
+                                ofn.lpstrInitialDir = NULL;
+                                ofn.Flags = OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT;
+
+                                GetSaveFileName(&ofn);
+
+                                name = fn;
+                            }
+#endif
+                            if(m_base.SaveToFile(name)) {
                                 m_success.SetText("Save Successful!");
                             } else {
                                 m_success.SetText("Save Failed :(");

--- a/gui/GUI_Element.cpp
+++ b/gui/GUI_Element.cpp
@@ -13,10 +13,10 @@ GUI_Element::GUI_Element(sf::RenderWindow* window, sf::Font* font, double x, dou
     m_cap("", *font),
     m_rectangle(sf::Vector2f(width, height))
 {
-    m_text.setColor(sf::Color::Black);
+    m_text.setFillColor(sf::Color::Black);
     m_text.setCharacterSize(15);
 
-    m_cap.setColor(sf::Color::Black);
+    m_cap.setFillColor(sf::Color::Black);
     m_cap.setCharacterSize(15);
 
     m_rectangle.setOutlineThickness(2);


### PR DESCRIPTION
With these changes, for fractals that grow to infinity, the Infinity button is treated as a single additional stage instead of trying to render forever and eventually crashing. Additionally, clicking Save or Load on Windows when the text box is empty brings up a standard Windows file dialog rather than requiring the user to type in a path. Finally, the left and right arrow keys in the Draw view move between adjacent levels.